### PR TITLE
fixed matching to prevent false matches

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -179,7 +179,7 @@ sub checkWhichDevice{
 				my $found = 0;# We have not found the device yet
 				foreach (@{$devices_h->{$key}->{'Device'}}){
 					# If the model matches we have found the correct db entry
-					if($currModel =~ $_){
+					if($currModel =~ /$_$/){
 						$found =1;
 						my %foundDevice_h;
 						# Clone the values from the JSON smart db, ensure to not work


### PR DESCRIPTION
For example "Western Digital Red (AF)" matched "Western Digital Re" in the database file.