### PR TITLE
Enhance cciss support to check multiple raidcontroller

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -151,7 +151,8 @@ sub getSmartctl{
 			my $devicePath = $2;
 			@output = `$smartctl -a -d $ccissDevice $devicePath`;
 			$ccissDevice =~ s/,/_/g;
-			$device = '/dev/'.$ccissDevice;
+			@controller = split(/\//,$devicePath);
+			$device = '/dev/'.$ccissDevice."_".$controller[-1];
 		}
 		else{
 			@output = `$smartctl -a $device`;


### PR DESCRIPTION
If there are multiple RAID controller you may want to check disks
from all of them.

I'm sorry i didn't think of this in the first commit.