### PR TITLE
Critical on unknown device / Fix listing of unknown devices

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -76,6 +76,8 @@ sub getHelpString{
         is defined in the user config it overrides its corresponding value in
         the base config. The override is only taken for the specific value, for
         the other ones the base config is still valid.
+  [-cu|--critical_on_unknown]
+        Show critical if the device was not found in database.
   [-nosudo]
         Disable the usage of sudo for smartctl. This is handy if a system is
         used where sudo is not available.
@@ -523,6 +525,7 @@ MAIN: {
 		'dbj|dbjson=s' => \$dbJSON,
 		'd|device=s' => \@devicesToCheck_a,
 		'ucfgj|ucfgjson=s' => \$uCfgJSON,
+        'cu|critical_on_unknown' => \$critical_on_unknown,
 		'nosudo' => \$noSudo,
 		'O|options=s' => \$extraOpts,
 		'V|version' => sub{
@@ -573,13 +576,23 @@ MAIN: {
 	my $devices_a = checkWhichDevice($dbConfig,$uCfg,$output_h);
 	if(!(@$devices_a)){
 		print "Error: device was not found in smartdb JSON file.\n";
-		exit(STATE_UNKNOWN);
+		if(!defined($critical_on_unknown)){
+			exit(STATE_UNKNOWN);
+		}
+		else {
+			exit(STATE_CRITICAL);
+		}
 	}
 	# Not all devices were found in the smartdb JSON
 	if(@$devices_a != @devicesToCheck_a){
 		print "Error: the following device(s) where not found in the smartdb JSON file: ";
 		print checkMissingDevicesDB(\@devicesToCheck_a,$devices_a);
-		exit(STATE_UNKNOWN);
+		if(!defined($critical_on_unknown)){
+			exit(STATE_UNKNOWN);
+		}
+		else {
+			exit(STATE_CRITICAL);
+		}
 	}
 	my $smartValues_h = parseSmartctlOut($output_h);
 	my $statusLevel_a = checkSmartctl($smartValues_h,$devices_a);

--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -164,6 +164,7 @@ sub getSmartctl{
 			exit(STATE_UNKNOWN);
 		}
 		$output_h{$device} = \@output;
+
 	}
 	return \%output_h;
 }
@@ -174,6 +175,7 @@ sub checkWhichDevice{
 	my %smartctlOut_h = %{(shift)};;
 	# Array of found device hashes
 	my @devices_a;
+	my @devices_missing_a;
 
 	# Fetch the device JSON hash
 	my $devices_h = $dbConfig->get("Devices");
@@ -184,15 +186,15 @@ sub checkWhichDevice{
 		$uCfgDevices_h = $uCfgJSON->get("Devices");
 	}
 
-	# Check all models in the db
-	foreach my $key (keys %$devices_h){
-		# Check each device whose smartvalues are present
-		foreach my $device (keys %smartctlOut_h){
-			my @smartctlOut = @{$smartctlOut_h{$device}};
-			my @model = grep { /Model Family/i || /Device Model/i } @smartctlOut;
-			foreach my $currModel (@model){
+	# Check each device whose smartvalues are present
+	foreach my $device (keys %smartctlOut_h){
+		my @smartctlOut = @{$smartctlOut_h{$device}};
+		my @model = grep { /Model Family/i || /Device Model/i } @smartctlOut;
+		my $found = 0;# We have not found the device yet
+		foreach my $currModel (@model){
+			# Check all models in the db
+			foreach my $key (keys %$devices_h){
 				# Search for the model in the smart DB
-				my $found = 0;# We have not found the device yet
 				foreach (@{$devices_h->{$key}->{'Device'}}){
 					# If the model matches we have found the correct db entry
 					if($currModel =~ /$_$/){
@@ -227,8 +229,11 @@ sub checkWhichDevice{
 				if($found){last;}
 			}
 		}
+		if(!$found){
+			push @devices_missing_a, $device;
+		}
 	}
-	return \@devices_a;
+	return (\@devices_a, \@devices_missing_a);
 }
 
 sub parseSmartctlOut{
@@ -347,23 +352,13 @@ sub checkSmartctl{
 	return \@statusLevel_a;
 }
 
-sub checkMissingDevicesDB{
-	my @devicesToCheck_a = @{(shift)};
+sub printMissingDevicesDB{
 	my @devices_a = @{(shift)};
 	my $missingDevs_str;
 	my $found;
-	foreach my $deviceToCheck (@devicesToCheck_a){
-		$found = 0;
-		foreach my $device (@devices_a){
-			if($deviceToCheck eq $device->{'Path'}){
-				$found = 1;
-				last;
-			}
-		}
-		if($found == 0){
-			$missingDevs_str .= ', ' if defined($missingDevs_str);
-			$missingDevs_str .= $deviceToCheck
-		}
+	foreach my $device (@devices_a){
+		$missingDevs_str .= ', ' if defined($missingDevs_str);
+		$missingDevs_str .= $device;
 	}
 	return $missingDevs_str;
 }
@@ -509,7 +504,7 @@ sub getVerboseString{
 }
 
 MAIN: {
-	my ($smartctl, $dbJSON, $uCfgJSON, $exitCode, $noSudo, $extraOpts);
+	my ($smartctl, $dbJSON, $uCfgJSON, $exitCode, $noSudo, $extraOpts, $critical_on_unknown);
 	my @devicesToCheck_a;
 	if ( !(GetOptions(
 		'v|verbose' => sub { $VERBOSITY = 1 },
@@ -525,7 +520,7 @@ MAIN: {
 		'dbj|dbjson=s' => \$dbJSON,
 		'd|device=s' => \@devicesToCheck_a,
 		'ucfgj|ucfgjson=s' => \$uCfgJSON,
-        'cu|critical_on_unknown' => \$critical_on_unknown,
+		'cu|critical_on_unknown' => \$critical_on_unknown,
 		'nosudo' => \$noSudo,
 		'O|options=s' => \$extraOpts,
 		'V|version' => sub{
@@ -573,20 +568,10 @@ MAIN: {
 	}
 	my $output_h = getSmartctl($smartctl,\@devicesToCheck_a,$extraOpts);
 	my $dbConfig = readDbJSON($dbJSON);
-	my $devices_a = checkWhichDevice($dbConfig,$uCfg,$output_h);
-	if(!(@$devices_a)){
-		print "Error: device was not found in smartdb JSON file.\n";
-		if(!defined($critical_on_unknown)){
-			exit(STATE_UNKNOWN);
-		}
-		else {
-			exit(STATE_CRITICAL);
-		}
-	}
-	# Not all devices were found in the smartdb JSON
-	if(@$devices_a != @devicesToCheck_a){
+	my ( $devices_a, $devices_missing_a ) = checkWhichDevice($dbConfig,$uCfg,$output_h);
+	if(@$devices_missing_a){
 		print "Error: the following device(s) where not found in the smartdb JSON file: ";
-		print checkMissingDevicesDB(\@devicesToCheck_a,$devices_a);
+		print printMissingDevicesDB($devices_missing_a);
 		if(!defined($critical_on_unknown)){
 			exit(STATE_UNKNOWN);
 		}
@@ -594,6 +579,7 @@ MAIN: {
 			exit(STATE_CRITICAL);
 		}
 	}
+
 	my $smartValues_h = parseSmartctlOut($output_h);
 	my $statusLevel_a = checkSmartctl($smartValues_h,$devices_a);
 


### PR DESCRIPTION
The first commit just introduces a new Option "-cu" or "--critical_on_unknown". It just alters the exit code when a device was not found in the database. In my organization we prefer critical over unknown states.

While testing on a system with two different devices behind a cciss controller both devices were listed in the output of missing drives, but only one was actually missing in the database.
I figured out that the subroutine checkMissingDevicesDB, which compares two lists, one list with all devices given by user via options and the other list from the already processed subroutine checkWhichDevice which contains all found devices. The problem comes when the device names were altered by getSmartctl, which is called in checkWhichDevice. As a result the device name from user input and in the list of found devices don't match anymore.
To address this problem checkWhichDevice just creates a second list with the devices not found in database and we can simply look for the missing devices in this list and print them.

Another approach would be to not alter the device names....

I suggest some testing with different systems before merging into master.
