### PR TITLE
Match value of "^Product:" in database.json

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -192,7 +192,7 @@ sub checkWhichDevice{
 	# Check each device whose smartvalues are present
 	foreach my $device (keys %smartctlOut_h){
 		my @smartctlOut = @{$smartctlOut_h{$device}};
-		my @model = grep { /Model Family/i || /Device Model/i } @smartctlOut;
+		my @model = grep { /Model Family/i || /Device Model/i || /^Product:/i } @smartctlOut;
 		my $found = 0;# We have not found the device yet
 		foreach my $currModel (@model){
 			# Check all models in the db


### PR DESCRIPTION
In order to handle smartctl output from HPE SAS SSD looking like this:
> === START OF INFORMATION SECTION ===
> Vendor:               HP
> Product:              EO0400FBRWA
> Revision:             HPD9
> User Capacity:        400,088,457,216 bytes [400 GB]
> Logical block size:   512 bytes
> Rotation Rate:        Solid State Device
> Form Factor:          2.5 inches
> Logical Unit id:      0x5001e82000032778
> Serial number:        00206712
> Device type:          disk
> Transport protocol:   SAS (SPL-3)