### PR TITLE
device symlink removed get abs_path with readlink

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -163,7 +163,7 @@ sub getSmartctl{
 			# If the device is a symlink, simply follow it
 			if(-l $device){
 				use Cwd qw(abs_path);
-				$device = abs_path(readlink $device);
+				$device = abs_path($device);
 			}
 			@output = `$smartctl -a $device`;
 		}


### PR DESCRIPTION
With readlink on abs_path it will fail to get disk by /dev/disk/by-id/XXX for example.