### PR TITLE
Add WDC WD40EFRX-68WT0N0

### DIFF
--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -1492,6 +1492,40 @@
 				"233": ["16:","6:"]
 			},
 			"Perfs" : ["233","241","242"]
+		},
+		"Western Digital Gold" : {
+		    "Device" : ["WDC WD2005FBYZ-01YCBB2" ],
+		    "ID#" : {
+			"1" : "VALUE", # Raw Read Error Rate
+			"3" : "VALUE", # Spin Up Time
+			"4" : "RAW_VALUE", # Start Stop Count
+			"5" : "RAW_VALUE", # Re-allocated Sector Count
+			"7" : "RAW_VALUE", # Seek Error Rate
+			"9" : "RAW_VALUE", # Power-On Hours
+			"10" : "RAW_VALUE", # Spin Retry Count
+			"11" : "RAW_VALUE", # Calibration Retry Count
+			"12" : "RAW_VALUE", # Power Cycle Count
+			"192" : "RAW_VALUE", # Power-Off Retract Count (Unsafe Shutdown Count)
+			"193" : "RAW_VALUE", # Load Cycle Count
+			"194" : "RAW_VALUE", # Temperature Celsius
+			"196" : "RAW_VALUE", # Reallocated Event Count
+			"197" : "RAW_VALUE", # Current Pending Sector
+			"198" : "RAW_VALUE", # Offline Uncorrectable
+			"199" : "RAW_VALUE", # UDMA CRC Error Count
+			"200" : "RAW_VALUE", # Multi Zone Error Rate
+		    },
+		    "Threshs" : {
+			"1" : ["62:","52:"],
+			"3" : ["32:","22:"],
+			"5" : ["20","40"],
+			"10" : ["0","10"],
+			"11" : ["0","10"],
+			"196" : ["0","10"],
+			"197" : ["0","10"],
+			"198" : ["0","10"],
+			"199" : ["0","10"],
+		    },
+		    "Perfs" : ["194"]
 		}
 	}
 }


### PR DESCRIPTION
Adds a Western Digital Gold-branded hard drive to the database.

A [ticket](https://www.smartmontools.org/ticket/1035) was created to add upstream support for this device in smartmontools.