### PR TITLE
Reversing temperature thresholds for MZ7KM480HMHQ0D3

### DIFF
--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -549,7 +549,7 @@
 				"184" : ["98:","97:"],
 				"187" : ["0","10"],
 				"190" : ["60","70"],
-				"194" : ["50","60"],
+				"194" : ["50:","40:"],
 				"195" : ["0","10"],
 				"197" : ["0","10"],
 				"199" : ["0","10"],
@@ -611,7 +611,7 @@
 				"183" : "RAW_VALUE", # Runtime Bad Block Count (Total)
 				"187" : "RAW_VALUE", # Uncorrectable Error Count
 				"190" : "RAW_VALUE", # Air Flow Temperature Celsius
-				"195" : "RAW_VALUE", # ECC Error Rate 
+				"195" : "RAW_VALUE", # ECC Error Rate
 				"199" : "RAW_VALUE", # CRC Error Count
 				"235" : "RAW_VALUE", # Power Recovery Count
 				"241" : "RAW_VALUE", # Total LBAs Written
@@ -1862,7 +1862,7 @@
 				"198" : "RAW_VALUE", # Offline Uncorrectable
 				"199" : "RAW_VALUE", # CRC Error Count
 				"233" : "VALUE", # Media Wearout Indicator
-			
+
 			},
 			"Threshs" : {
 				"1" : ["62:","52:"],


### PR DESCRIPTION
Hi,

for the hard drive with model number `MZ7KM480HMHQ0D3` the temperature threshold values seem to be reversed. I can only speak for this model and not others in this section.
Further more I am not sure if I revered the values correctly with `:` without changing the intended values. I couldn't find documentation for it, so I did it analogously to similar values.

If you want I could split the section for this model.


```
smartctl 6.4 2014-10-07 r4002 [x86_64-linux-3.16.0-5-amd64] (local build)
Copyright (C) 2002-14, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     MZ7KM480HMHQ0D3
Serial Number:    S3BUNY0J408011
LU WWN Device Id: 5 002538 c000e7e27
Add. Product Id:  DELL(tm)
Firmware Version: GD53
User Capacity:    480,103,981,056 bytes [480 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Oct 24 10:52:41 2018 CEST
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x02)	Offline data collection activity
					was completed without error.
					Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
Total time to complete Offline 
data collection: 		( 2100) seconds.
Offline data collection
capabilities: 			 (0x5b) SMART execute Offline immediate.
					Auto Offline data collection on/off support.
					Suspend Offline collection upon new
					command.
					Offline surface scan supported.
					Self-test supported.
					No Conveyance Self-test supported.
					Selective Self-test supported.
SMART capabilities:            (0x0003)	Saves SMART data before entering
					power-saving mode.
					Supports SMART auto save timer.
Error logging capability:        (0x01)	Error logging supported.
					General Purpose Logging supported.
Short self-test routine 
recommended polling time: 	 (   2) minutes.
Extended self-test routine
recommended polling time: 	 (  35) minutes.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x001a   200   200   000    Old_age   Always       -       0
  5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0032   097   097   000    Old_age   Always       -       12388
 12 Power_Cycle_Count       0x0032   099   099   000    Old_age   Always       -       43
 13 Read_Soft_Error_Rate    0x001a   200   200   000    Old_age   Always       -       0
177 Wear_Leveling_Count     0x0013   099   099   005    Pre-fail  Always       -       16
179 Used_Rsvd_Blk_Cnt_Tot   0x0013   100   100   010    Pre-fail  Always       -       0
180 Unused_Rsvd_Blk_Cnt_Tot 0x0012   100   100   000    Old_age   Always       -       2776
181 Program_Fail_Cnt_Total  0x0032   100   100   000    Old_age   Always       -       0
182 Erase_Fail_Count_Total  0x0032   100   100   000    Old_age   Always       -       0
184 End-to-End_Error        0x0033   100   100   097    Pre-fail  Always       -       0
194 Temperature_Celsius     0x0022   057   039   000    Old_age   Always       -       43
195 Hardware_ECC_Recovered  0x001a   100   100   000    Old_age   Always       -       0
198 Offline_Uncorrectable   0x0030   100   100   000    Old_age   Offline      -       0
199 UDMA_CRC_Error_Count    0x003e   100   100   000    Old_age   Always       -       0
201 Unknown_SSD_Attribute   0x0033   100   100   001    Pre-fail  Always       -       0
202 Unknown_SSD_Attribute   0x0033   100   100   010    Pre-fail  Always       -       0
233 Media_Wearout_Indicator 0x0032   099   099   000    Old_age   Always       -       618811083
235 Unknown_Attribute       0x0012   099   099   000    Old_age   Always       -       36
242 Total_LBAs_Read         0x0032   099   099   000    Old_age   Always       -       378855142
243 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       0
244 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       0
245 Unknown_Attribute       0x003a   099   099   000    Old_age   Always       -       99
246 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       65535
247 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       65535
248 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       65535
251 Unknown_Attribute       0x0032   100   100   000    Old_age   Always       -       16978331136

SMART Error Log Version: 1
No Errors Logged

SMART Self-test log structure revision number 1
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%         3         -
# 2  Extended offline    Completed without error       00%         2         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
  255        0    65535  Read_scanning was completed without error
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.
```