### PR TITLE
Add collection of new drives to the SMART DB

### DIFF
--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -2573,6 +2573,37 @@
 				"1025" : ["0","0"]
 		    },
 		    "Perfs" : ["194"]
+		},
+    "Hitachi CinemaStar 5K2000": {
+			"Device" : ["Hitachi HCS5C2020ALA632"],
+			"ID#" : {
+				"1" : {"value": "VALUE", "comment": "Raw Read Error Rate"},
+				"2" : {"value": "VALUE", "comment": "Throughput Performance"},
+				"3" : {"value": "VALUE", "comment": "Spin-up Time"},
+				"4" : {"value": "VALUE", "comment": "Start Stop Count"},
+				"5" : {"value": "VALUE", "comment": "Reallocated Sector Count"},
+				"7" : {"value": "VALUE", "comment": "Seek Error Rate"},
+				"8" : {"value": "VALUE", "comment": "Seek Time Performance"},
+				"9" : {"value": "RAW_VALUE", "comment": "Power On Hours"},
+				"10" : {"value": "VALUE", "comment": "Spin Retry Count"},
+				"12" : {"value": "RAW_VALUE", "comment": "Power Cycle Count"},
+				"192" : {"value": "RAW_VALUE", "comment": "Power Off Retract Count"},
+				"193" : {"value": "RAW_VALUE", "comment": "Load Cycle Count"},
+				"194" : {"value": "RAW_VALUE", "comment": "Temperature Celcius"},
+				"196" : {"value": "RAW_VALUE", "comment": "Reallocated Event Count"},
+				"197" : {"value": "VALUE", "comment": "Current Pending Sector"},
+				"198" : {"value": "VALUE", "comment": "Offline Uncorrectable"},
+				"199" : {"value": "VALUE", "comment": "UDMA CRC Error Count"}
+			},
+			"Threshs" : {
+				"1" : ["20:","16:"],
+				"2" : ["60:","40:"],
+				"5" : ["10:","5:"],
+				"7" : ["70:","50:"],
+				"8" : ["30:","20:"],
+				"10" : ["60:","50:"]
+			},
+			"Perfs" : ["3","9","12","194"]
 		}
 	}
 }

--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -1752,7 +1752,7 @@
 			"Perfs" : ["190","194"]
 		},
 		"Seagate Constellation ES" : {
-			"Device" : ["Seagate Constellation ES", "ST32000644NS"],
+			"Device" : ["Seagate Constellation ES", "ST32000644NS", "ST2000NM0011"],
 			"ID#" : {
 				"1" : {"value": "VALUE", "comment": "Raw Read Error Rate"},
 				"3" : {"value": "VALUE", "comment": "Spin Up Time"},

--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -1982,7 +1982,7 @@
 			"Perfs" : ["233","241","242"]
 		},
 		"Seagate Constellation ES.3 SATA" : {
-			"Device" : ["Seagate Constellation ES.3", "ST1000NM0033", "ST2000NM0033", "ST3000NM0033", "ST4000NM0033", "ST2000NM0033-9ZM175"],
+			"Device" : ["Seagate Constellation ES.3", "ST1000NM0033", "ST2000NM0033", "ST3000NM0033", "ST4000NM0033", "ST2000NM0033-9ZM175", "ST2000NM0008-2F3100"],
 			"ID#" : {
 				"5" : {"value": "RAW_VALUE", "comment": "Re-allocated Sector Count"},
 				"9" : {"value": "RAW_VALUE", "comment": "Power-On Hours Count"},

--- a/check_smartdb.json
+++ b/check_smartdb.json
@@ -1982,7 +1982,7 @@
 			"Perfs" : ["233","241","242"]
 		},
 		"Seagate Constellation ES.3 SATA" : {
-			"Device" : ["Seagate Constellation ES.3", "ST1000NM0033", "ST2000NM0033", "ST3000NM0033", "ST4000NM0033"],
+			"Device" : ["Seagate Constellation ES.3", "ST1000NM0033", "ST2000NM0033", "ST3000NM0033", "ST4000NM0033", "ST2000NM0033-9ZM175"],
 			"ID#" : {
 				"5" : {"value": "RAW_VALUE", "comment": "Re-allocated Sector Count"},
 				"9" : {"value": "RAW_VALUE", "comment": "Power-On Hours Count"},


### PR DESCRIPTION
A handful of drives have been used in machines either in my homelab or at work, so I've added them to the check_smartdb. May as well have them merged into the mainstream environment!

Note that these have not necessarily been added with reference to official documentation - it's a "best-efforts" addition.