### PR TITLE
Do not parse "Error Information Log" on NVMe devices

### DIFF
--- a/check_smart_attributes
+++ b/check_smart_attributes
@@ -496,7 +496,8 @@ sub parseSmartctlOut{
 		my @splittedLine;
 		my @transport = grep { /^Transport protocol:/i } @smartctlOut;
 		foreach my $line (@smartctlOut) {
-			if($line =~ /\d+\s+[A-Za-z0-9_\/]+\s+0[xX][0-9a-fA-F]+\s+\d+\s+\d+\s+[0-9\-]+\s+\w+/){
+			# Skip NVMe to avoid parsing "Error Information Log", which results into false-positive alarms
+			if((($device !~ /nvme[a-z0-9]+$/) && ($device !~ /\/dev\/disk\/by-id\/nvme-[A-Za-z0-9_\-,\.\:]+$/)) && $line =~ /\d+\s+[A-Za-z0-9_\/]+\s+0[xX][0-9a-fA-F]+\s+\d+\s+\d+\s+[0-9\-]+\s+\w+/){
 				$line =~ s/^\s+|\s+$//g;
 				# Split the found line, and map its elements
 				# The header map defines the keys for the hash


### PR DESCRIPTION
smartctl shows the error information log on an NVMe device:

```
Error Information (NVMe Log 0x01, max 63 entries)
Num   ErrCount  SQId   CmdId  Status  PELoc          LBA  NSID    VS  Message
  0       9503     0  0xb00b  0x421e  0x004            0     1     -  Feature Not Namespace Specific
  1       9502     0  0x001d  0x421e  0x004            0     1     -  Feature Not Namespace Specific
```

The regex matches the ErrCount and Message field, which results into false positive alerts and errors in the check output:
```
~ [#] ./check_smart_attributes -dbj check_smartdb.json -r '"/dev/(sd[a-z]|nvme[0-9]{1,}n[0-9]{1,})"'
Argument "Feature" isn't numeric in numeric lt (<) at /usr/lib64/nagios/plugins/check_smart_attributes line 599.
Critical (2 devices) [nvme0n1p1_Error_Information_Log_Entries = Critical][nvme0n1p1_3078 = Critical]
```

This will also solve the issue reported in #130